### PR TITLE
chore: add MIT (code) and CC BY 4.0 (content) licenses

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,31 @@
+MIT License
+
+Copyright (c) 2026 Konilo Zio
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+The MIT License above applies to the source code in this repository.
+
+The prose, figures, and rendered study content (e.g., the contents of `.qmd`
+files outside of code chunks, and the resulting website at
+https://konilo.github.io/sandbox/) are licensed separately under the Creative
+Commons Attribution 4.0 International License (CC BY 4.0). See LICENSE-CONTENT
+for the full text, or visit https://creativecommons.org/licenses/by/4.0/.

--- a/LICENSE-CONTENT
+++ b/LICENSE-CONTENT
@@ -1,0 +1,34 @@
+Creative Commons Attribution 4.0 International (CC BY 4.0)
+
+Copyright (c) 2026 Konilo Zio
+
+The prose, figures, and rendered study content in this repository — including
+the text of `.qmd` files (outside of code chunks) and the rendered website at
+https://konilo.github.io/sandbox/ — are licensed under the Creative Commons
+Attribution 4.0 International License.
+
+You are free to:
+
+  - Share — copy and redistribute the material in any medium or format
+  - Adapt — remix, transform, and build upon the material for any purpose,
+    even commercially
+
+Under the following terms:
+
+  - Attribution — You must give appropriate credit, provide a link to the
+    license, and indicate if changes were made. You may do so in any
+    reasonable manner, but not in any way that suggests the licensor endorses
+    you or your use.
+
+No additional restrictions — You may not apply legal terms or technological
+measures that legally restrict others from doing anything the license
+permits.
+
+The full legal text of the license is available at:
+https://creativecommons.org/licenses/by/4.0/legalcode
+
+A human-readable summary is available at:
+https://creativecommons.org/licenses/by/4.0/
+
+Note: source code in this repository is licensed separately under the MIT
+License. See the LICENSE file.

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -18,6 +18,10 @@ website:
       - icon: github
         href: https://github.com/Konilo/sandbox
         aria-label: GitHub
+  page-footer:
+    center: |
+      Code: [MIT](https://github.com/Konilo/sandbox/blob/main/LICENSE) ·
+      Text & figures: [CC BY 4.0](https://github.com/Konilo/sandbox/blob/main/LICENSE-CONTENT)
   sidebar:
     style: docked
     search: true


### PR DESCRIPTION
## Summary
- Add `LICENSE` (MIT) covering source code.
- Add `LICENSE-CONTENT` (CC BY 4.0) covering prose, figures, and rendered study content.
- Add a `page-footer` in `_quarto.yml` linking to both licenses on every site page.

## Test plan
- [x] `quarto render index.qmd` succeeds with the new footer config.
- [ ] After merge, confirm the footer renders on the deployed GitHub Pages site.